### PR TITLE
Use GroundDB and AppCache in browser

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -26,3 +26,4 @@ twbs:bootstrap
 iron:router
 aldeed:simple-schema
 aldeed:collection2
+appcache

--- a/.meteor/platforms
+++ b/.meteor/platforms
@@ -1,3 +1,4 @@
 android
 browser
+ios
 server

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -2,6 +2,7 @@ aldeed:autoform@5.8.1
 aldeed:collection2@2.3.1
 aldeed:simple-schema@1.1.0
 allow-deny@1.0.5
+appcache@1.0.11
 autoupdate@1.2.11
 babel-compiler@6.13.0
 babel-runtime@1.0.1

--- a/imports/api/collections/contacts.js
+++ b/imports/api/collections/contacts.js
@@ -35,7 +35,5 @@ Contacts.allow({
 		return true;
 	}
 });
- 
-if (Meteor.isCordova) {
-  Ground.Collection(Contacts);
-}
+
+Ground.Collection(Contacts);


### PR DESCRIPTION
Temporary solution for use on iOS Safari.